### PR TITLE
fix: bump langchain-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 requires-python = ">=3.10,<4.0"
 version = "0.2.0"
 
-dependencies = ["langchain-core", "linkup-sdk>=0.11.0"]
+dependencies = ["langchain-core>=1.2.22", "linkup-sdk>=0.11.0"]
 
 [project.optional-dependencies]
 build = ["uv>=0.10.0,<0.11.0"] # For python-semantic-release build command, used in GitHub actions
@@ -91,5 +91,6 @@ version_toml = ["pyproject.toml:project.version"]
 parse_squash_commits = false
 
 [tool.uv]
-exclude-newer = "2 weeks" # Reduce risks of supply chain attacks
+# TODO: put `exclude-newer` back to 2 weeks when possible
+exclude-newer = "5 days" # Reduce risks of supply chain attacks
 required-version = ">=0.10.0,<0.11.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,25 +1,20 @@
 [project]
-name="langchain-linkup"
-version="0.2.0"
-description = "A Langchain integration for the Linkup API"
-readme = "README.md"
-keywords = ["linkup", "api", "langchain", "integration", "search", "retriever"]
-license = "MIT"
-requires-python = ">=3.10,<4.0"
-authors = [
-  { name = "LINKUP TECHNOLOGIES", email = "contact@linkup.so" }
-]
+authors = [{ email = "contact@linkup.so", name = "LINKUP TECHNOLOGIES" }]
 classifiers = [
   "Intended Audience :: Developers",
-  "Topic :: Software Development :: Libraries :: Python Modules",
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
+  "Topic :: Software Development :: Libraries :: Python Modules",
 ]
+description = "A Langchain integration for the Linkup API"
+keywords = ["api", "integration", "langchain", "linkup", "retriever", "search"]
+license = "MIT"
+name = "langchain-linkup"
+readme = "README.md"
+requires-python = ">=3.10,<4.0"
+version = "0.2.0"
 
-dependencies = [
-  "langchain-core",
-  "linkup-sdk>=0.11.0",
-]
+dependencies = ["langchain-core", "linkup-sdk>=0.11.0"]
 
 [project.optional-dependencies]
 build = ["uv>=0.10.0,<0.11.0"] # For python-semantic-release build command, used in GitHub actions
@@ -42,8 +37,8 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/LinkupPlatform/langchain-linkup"
 Documentation = "https://github.com/LinkupPlatform/langchain-linkup#readme"
+Homepage = "https://github.com/LinkupPlatform/langchain-linkup"
 Source = "https://github.com/LinkupPlatform/langchain-linkup"
 Tracker = "https://github.com/LinkupPlatform/langchain-linkup/issues"
 
@@ -56,7 +51,7 @@ asyncio_default_fixture_loop_scope = "function"
 asyncio_mode = "auto" # Prevent some async tests in langchain-tests to be skipped
 
 [tool.coverage.report]
-exclude_also = ["raise ValueError", "raise TypeError"]
+exclude_also = ["raise TypeError", "raise ValueError"]
 
 [tool.ruff]
 line-length = 100
@@ -71,8 +66,8 @@ select = [
 ]
 
 [build-system]
-requires = ["hatchling"]
 build-backend = "hatchling.build"
+requires = ["hatchling"]
 
 [tool.ruff.lint.extend-per-file-ignores]
 "tests/**/test_*.py" = ["S101"] # Use of assert detected

--- a/uv.lock
+++ b/uv.lock
@@ -8,8 +8,8 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-03-12T09:20:52.156902Z"
-exclude-newer-span = "P2W"
+exclude-newer = "2026-03-25T07:26:58.931738Z"
+exclude-newer-span = "P5D"
 
 [[package]]
 name = "annotated-types"
@@ -546,7 +546,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.17"
+version = "1.2.22"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -558,9 +558,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/93/36226f593df52b871fc24d494c274f3a6b2ac76763a2806e7d35611634a1/langchain_core-1.2.17.tar.gz", hash = "sha256:54aa267f3311e347fb2e50951fe08e53761cebfb999ab80e6748d70525bbe872", size = 836130, upload-time = "2026-03-02T22:47:55.846Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/a3/c4cd6827a1df46c821e7214b7f7b7a28b189e6c9b84ef15c6d629c5e3179/langchain_core-1.2.22.tar.gz", hash = "sha256:8d8f726d03d3652d403da915126626bb6250747e8ba406537d849e68b9f5d058", size = 842487, upload-time = "2026-03-24T18:48:44.9Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/90/073f33ab383a62908eca7ea699586dfea280e77182176e33199c80ddf22a/langchain_core-1.2.17-py3-none-any.whl", hash = "sha256:bf6bd6ce503874e9c2da1669a69383e967c3de1ea808921d19a9a6bff1a9fbbe", size = 502727, upload-time = "2026-03-02T22:47:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/a6/2ffacf0f1a3788f250e75d0b52a24896c413be11be3a6d42bcdf46fbea48/langchain_core-1.2.22-py3-none-any.whl", hash = "sha256:7e30d586b75918e828833b9ec1efc25465723566845dd652c277baf751e9c04b", size = 506829, upload-time = "2026-03-24T18:48:43.286Z" },
 ]
 
 [[package]]
@@ -596,7 +596,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain-core" },
+    { name = "langchain-core", specifier = ">=1.2.22" },
     { name = "linkup-sdk", specifier = ">=0.11.0" },
     { name = "uv", marker = "extra == 'build'", specifier = ">=0.10.0,<0.11.0" },
 ]


### PR DESCRIPTION
PR is best reviewed commit-by-commit.

- **chore: format pyproject.toml with taplo**
  

- **fix: bump langchain-core**
  See https://github.com/LinkupPlatform/langchain-linkup/security/dependabot/16.
  